### PR TITLE
Use ed25519-consensus instead of ed25519-dalek

### DIFF
--- a/config/src/node_key.rs
+++ b/config/src/node_key.rs
@@ -36,7 +36,7 @@ impl NodeKey {
     pub fn public_key(&self) -> PublicKey {
         #[allow(unreachable_patterns)]
         match &self.priv_key {
-            PrivateKey::Ed25519(keypair) => keypair.public.into(),
+            PrivateKey::Ed25519(signing_key) => PublicKey::Ed25519(signing_key.verification_key()),
             _ => unreachable!(),
         }
     }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -28,7 +28,7 @@ amino = ["prost-derive"]
 
 [dependencies]
 chacha20poly1305 = { version = "0.8", default-features = false, features = ["reduced-round"] }
-ed25519-dalek = { version = "1", default-features = false }
+ed25519-consensus = { version = "1.2", default-features = false }
 eyre = { version = "0.6", default-features = false }
 flume = { version = "0.10.7", default-features = false }
 hkdf = { version = "0.10.0", default-features = false }
@@ -37,7 +37,7 @@ prost = { version = "0.9", default-features = false }
 rand_core = { version = "0.5", default-features = false, features = ["std"] }
 sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2", default-features = false }
-x25519-dalek = { version = "1.1", default-features = false }
+x25519-dalek = { version = "1.1", default-features = false, features = ["u64_backend"] }
 zeroize = { version = "1", default-features = false }
 signature = { version = "1.3.0", default-features = false }
 aead = { version = "0.4.1", default-features = false }

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -2,7 +2,6 @@
 
 use flex_error::{define_error, DisplayOnly};
 use prost::DecodeError;
-use signature::Error as SignatureError;
 
 define_error! {
     Error {
@@ -36,7 +35,6 @@ define_error! {
             | _ | { "public key missing" },
 
         Signature
-            [ DisplayOnly<SignatureError> ]
             | _ | { "signature error" },
 
         UnsupportedKey

--- a/p2p/src/secret_connection/amino_types.rs
+++ b/p2p/src/secret_connection/amino_types.rs
@@ -2,7 +2,6 @@
 
 use crate::error::Error;
 use core::convert::TryFrom;
-use ed25519_dalek as ed25519;
 use prost_derive::Message;
 use tendermint_proto as proto;
 
@@ -22,13 +21,16 @@ pub struct AuthSigMessage {
 }
 
 impl AuthSigMessage {
-    pub fn new(pub_key: &ed25519::PublicKey, sig: &ed25519::Signature) -> Self {
+    pub fn new(
+        pub_key: &ed25519_consensus::VerificationKey,
+        sig: &ed25519_consensus::Signature,
+    ) -> Self {
         let mut pub_key_bytes = Vec::from(PUB_KEY_ED25519_AMINO_PREFIX);
-        pub_key_bytes.extend_from_slice(pub_key.as_ref());
+        pub_key_bytes.extend_from_slice(pub_key.as_bytes());
 
         Self {
             pub_key: pub_key_bytes,
-            sig: sig.as_ref().to_vec(),
+            sig: sig.to_bytes().to_vec(),
         }
     }
 }

--- a/p2p/src/secret_connection/protocol.rs
+++ b/p2p/src/secret_connection/protocol.rs
@@ -2,7 +2,6 @@
 
 use std::convert::TryInto;
 
-use ed25519_dalek as ed25519;
 use prost::Message as _;
 
 use x25519_dalek::PublicKey as EphemeralPublic;
@@ -113,8 +112,8 @@ impl Version {
     #[must_use]
     pub fn encode_auth_signature(
         self,
-        pub_key: &ed25519::PublicKey,
-        signature: &ed25519::Signature,
+        pub_key: &ed25519_consensus::VerificationKey,
+        signature: &ed25519_consensus::Signature,
     ) -> Vec<u8> {
         if self.is_protobuf() {
             // Protobuf `AuthSigMessage`
@@ -126,7 +125,7 @@ impl Version {
 
             let msg = proto::p2p::AuthSigMessage {
                 pub_key: Some(pub_key),
-                sig: signature.as_ref().to_vec(),
+                sig: signature.to_bytes().to_vec(),
             };
 
             let mut buf = Vec::new();
@@ -168,8 +167,8 @@ impl Version {
     #[cfg(feature = "amino")]
     fn encode_auth_signature_amino(
         self,
-        pub_key: &ed25519::PublicKey,
-        signature: &ed25519::Signature,
+        pub_key: &ed25519_consensus::VerificationKey,
+        signature: &ed25519_consensus::Signature,
     ) -> Vec<u8> {
         // Legacy Amino encoded `AuthSigMessage`
         let msg = amino_types::AuthSigMessage::new(pub_key, signature);
@@ -184,8 +183,8 @@ impl Version {
     #[cfg(not(feature = "amino"))]
     fn encode_auth_signature_amino(
         self,
-        _: &ed25519::PublicKey,
-        _: &ed25519::Signature,
+        _: &ed25519_consensus::VerificationKey,
+        _: &ed25519_consensus::Signature,
     ) -> Vec<u8> {
         panic!("attempted to encode auth signature using amino, but 'amino' feature is not present")
     }

--- a/pbt-gen/src/time.rs
+++ b/pbt-gen/src/time.rs
@@ -21,7 +21,6 @@ pub const MAX_NANO_SECS: u32 = 999_999_999u32;
 /// let timestamp = pbt_gen::time::min_time().unix_timestamp_nanos();
 /// assert!(OffsetDateTime::from_unix_timestamp_nanos(timestamp).is_ok());
 /// assert!(OffsetDateTime::from_unix_timestamp_nanos(timestamp - 1).is_err());
-///
 /// ```
 pub fn min_time() -> OffsetDateTime {
     Date::MIN.midnight().assume_utc()
@@ -49,7 +48,6 @@ pub fn max_time() -> OffsetDateTime {
 /// Google's well-known [`Timestamp`] protobuf message format.
 ///
 /// [`Timestamp`]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
-///
 pub const fn min_protobuf_time() -> OffsetDateTime {
     datetime!(0001-01-01 00:00:00 UTC)
 }
@@ -58,7 +56,6 @@ pub const fn min_protobuf_time() -> OffsetDateTime {
 /// Google's well-known [`Timestamp`] protobuf message format.
 ///
 /// [`Timestamp`]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
-///
 pub const fn max_protobuf_time() -> OffsetDateTime {
     datetime!(9999-12-31 23:59:59.999999999 UTC)
 }
@@ -248,7 +245,6 @@ prop_compose! {
 /// Google's well-known [`Timestamp`] protobuf message format.
 ///
 /// [`Timestamp`]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
-///
 pub fn arb_protobuf_safe_rfc3339_timestamp() -> impl Strategy<Value = String> {
     arb_rfc3339_timestamp().prop_filter("timestamp out of protobuf range", |ts| {
         let t = OffsetDateTime::parse(ts, &Rfc3339).unwrap();

--- a/proto/src/serializers/timestamp.rs
+++ b/proto/src/serializers/timestamp.rs
@@ -90,7 +90,6 @@ pub fn to_rfc3339_nanos(t: OffsetDateTime) -> String {
 ///
 /// [`Display`]: core::fmt::Display
 /// [`Debug`]: core::fmt::Debug
-///
 pub fn fmt_as_rfc3339_nanos(t: OffsetDateTime, f: &mut impl fmt::Write) -> fmt::Result {
     let t = t.to_offset(offset!(UTC));
     let nanos = t.nanosecond();

--- a/tendermint/Cargo.toml
+++ b/tendermint/Cargo.toml
@@ -36,7 +36,7 @@ crate-type = ["cdylib", "rlib"]
 async-trait = { version = "0.1", default-features = false }
 bytes = { version = "1.0", default-features = false, features = ["serde"] }
 ed25519 = { version = "1.3", default-features = false }
-ed25519-dalek = { version = "1", default-features = false, features = ["u64_backend"] }
+ed25519-consensus = { version = "1.2", default-features = false }
 futures = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 once_cell = { version = "1.3", default-features = false }

--- a/tendermint/src/account.rs
+++ b/tendermint/src/account.rs
@@ -162,7 +162,7 @@ mod tests {
         let id_bytes = Id::from_str(id_hex).expect("expected id_hex to decode properly");
 
         // get id for pubkey
-        let pubkey = Ed25519::from_bytes(pubkey_bytes).unwrap();
+        let pubkey = Ed25519::try_from(&pubkey_bytes[..]).unwrap();
         let id = Id::from(pubkey);
 
         assert_eq!(id_bytes.ct_eq(&id).unwrap_u8(), 1);

--- a/tendermint/src/error.rs
+++ b/tendermint/src/error.rs
@@ -208,8 +208,7 @@ define_error! {
             |_| { format_args!("subtle encoding error") },
 
         Signature
-            [ DisplayOnly<signature::Error> ]
-            |_| { format_args!("signature error") },
+            |_| { "signature error" },
 
         TrustThresholdTooLarge
             |_| { "trust threshold is too large (must be <= 1)" },

--- a/tendermint/src/signature.rs
+++ b/tendermint/src/signature.rs
@@ -88,8 +88,14 @@ impl AsRef<[u8]> for Signature {
 }
 
 impl From<Ed25519Signature> for Signature {
-    fn from(pk: Ed25519Signature) -> Signature {
-        Self(pk.as_ref().to_vec())
+    fn from(sig: Ed25519Signature) -> Signature {
+        Self(sig.as_ref().to_vec())
+    }
+}
+
+impl From<ed25519_consensus::Signature> for Signature {
+    fn from(sig: ed25519_consensus::Signature) -> Signature {
+        Self(sig.to_bytes().to_vec())
     }
 }
 

--- a/tendermint/src/time.rs
+++ b/tendermint/src/time.rs
@@ -30,7 +30,6 @@ use crate::error::Error;
 /// This reproduces the behavior of Go's `time.RFC3339Nano` format.
 ///
 /// [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
-///
 // For memory efficiency, the inner member is `PrimitiveDateTime`, with assumed
 // UTC offset. The `assume_utc` method is used to get the operational
 // `OffsetDateTime` value.

--- a/tendermint/src/validator.rs
+++ b/tendermint/src/validator.rs
@@ -268,7 +268,7 @@ impl From<&Info> for SimpleValidator {
     fn from(info: &Info) -> SimpleValidator {
         let sum = match &info.pub_key {
             PublicKey::Ed25519(pk) => Some(tendermint_proto::crypto::public_key::Sum::Ed25519(
-                pk.as_bytes().to_vec(),
+                pk.as_ref().to_vec(),
             )),
             #[cfg(feature = "secp256k1")]
             PublicKey::Secp256k1(pk) => Some(tendermint_proto::crypto::public_key::Sum::Secp256k1(

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -14,10 +14,10 @@ authors     = ["Alexander Simmerl <a.simmerl@gmail.com>"]
 test = true
 
 [dev-dependencies]
-ed25519-dalek = { version = "1", default-features = false, features = ["rand"] }
+ed25519-consensus = { version = "1.2", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 flume = { version = "0.10", default-features = false }
-rand_core = { version = "0.5", default-features = false, features = ["std"] }
+rand_core = { version = "0.6", default-features = false, features = ["std"] }
 readwrite = { version = "^0.1.1", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }
 x25519-dalek = { version = "1.1", default-features = false }

--- a/test/src/test/unit/p2p/secret_connection.rs
+++ b/test/src/test/unit/p2p/secret_connection.rs
@@ -3,7 +3,7 @@ use std::io::Write as _;
 use std::net::{TcpListener, TcpStream};
 use std::thread;
 
-use ed25519_dalek::{self as ed25519};
+use ed25519_consensus;
 use rand_core::OsRng;
 use x25519_dalek::PublicKey as EphemeralPublic;
 
@@ -64,7 +64,7 @@ fn test_read_write_single_message() {
 #[test]
 fn test_evil_peer_shares_invalid_eph_key() {
     let mut csprng = OsRng {};
-    let local_privkey: ed25519::Keypair = ed25519::Keypair::generate(&mut csprng);
+    let local_privkey = ed25519_consensus::SigningKey::new(&mut csprng);
     let (mut h, _) = Handshake::new(local_privkey, Version::V0_34);
     let bytes: [u8; 32] = [0; 32];
     let res = h.got_key(EphemeralPublic::from(bytes));
@@ -74,7 +74,7 @@ fn test_evil_peer_shares_invalid_eph_key() {
 #[test]
 fn test_evil_peer_shares_invalid_auth_sig() {
     let mut csprng = OsRng {};
-    let local_privkey: ed25519::Keypair = ed25519::Keypair::generate(&mut csprng);
+    let local_privkey = ed25519_consensus::SigningKey::new(&mut csprng);
     let (mut h, _) = Handshake::new(local_privkey, Version::V0_34);
     let res = h.got_key(EphemeralPublic::from(x25519_dalek::X25519_BASEPOINT_BYTES));
     assert!(res.is_ok());
@@ -186,6 +186,6 @@ where
     IoHandler: std::io::Read + std::io::Write + Send + Sync,
 {
     let mut csprng = OsRng {};
-    let privkey1: ed25519::Keypair = ed25519::Keypair::generate(&mut csprng);
+    let privkey1 = ed25519_consensus::SigningKey::new(&mut csprng);
     SecretConnection::new(io_handler, privkey1, Version::V0_34)
 }

--- a/testgen/Cargo.toml
+++ b/testgen/Cargo.toml
@@ -19,7 +19,7 @@ description = """
 tendermint = { version = "0.23.0", path = "../tendermint" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
-ed25519-dalek = { version = "1", default-features = false }
+ed25519-consensus = { version = "1.2", default-features = false }
 gumdrop = { version = "0.8.0", default-features = false }
 simple-error = { version = "0.2.1", default-features = false }
 tempfile = { version = "3.1.0", default-features = false }

--- a/testgen/src/helpers.rs
+++ b/testgen/src/helpers.rs
@@ -3,11 +3,7 @@
 use serde::de::DeserializeOwned;
 use simple_error::*;
 use std::io::{self, Read};
-use tendermint::{
-    chain, public_key,
-    signature::{Signature, Verifier},
-    vote, Time,
-};
+use tendermint::{chain, public_key, signature::Signature, vote, Time};
 
 /// A macro that generates a complete setter method from a one-liner with necessary information
 #[macro_export]
@@ -51,8 +47,8 @@ pub fn get_vote_sign_bytes(chain_id: chain::Id, vote: &vote::Vote) -> Vec<u8> {
 pub fn verify_signature(verifier: &public_key::Ed25519, msg: &[u8], signature: &Signature) -> bool {
     use std::convert::TryFrom;
 
-    let sig = ed25519_dalek::Signature::try_from(signature.as_bytes());
-    sig.and_then(|sig| verifier.verify(msg, &sig)).is_ok()
+    let sig = ed25519_consensus::Signature::try_from(signature.as_bytes());
+    sig.and_then(|sig| verifier.verify(&sig, msg)).is_ok()
 }
 
 pub fn get_time(abs: u64) -> Result<Time, SimpleError> {

--- a/testgen/src/validator.rs
+++ b/testgen/src/validator.rs
@@ -1,5 +1,5 @@
 use crate::{helpers::*, Generator};
-use ed25519_dalek::SecretKey as Ed25519SecretKey;
+use ed25519_consensus::SigningKey as Ed25519SigningKey;
 use gumdrop::Options;
 use serde::{Deserialize, Serialize};
 use simple_error::*;
@@ -47,17 +47,17 @@ impl Validator {
             bail!("validator identifier is too long")
         }
         bytes.extend(vec![0u8; 32 - bytes.len()].iter());
-        let secret = require_with!(
-            Ed25519SecretKey::from_bytes(&bytes).ok(),
+        let signing_key = require_with!(
+            Ed25519SigningKey::try_from(&bytes[..]).ok(),
             "failed to construct a seed from validator identifier"
         );
-        let public = public_key::Ed25519::from(&secret);
-        Ok(private_key::Ed25519 { secret, public })
+        Ok(signing_key)
     }
 
     /// Get public key for this validator companion.
     pub fn get_public_key(&self) -> Result<public_key::Ed25519, SimpleError> {
-        self.get_private_key().map(|keypair| keypair.public)
+        self.get_private_key()
+            .map(|secret_key| secret_key.verification_key())
     }
 }
 
@@ -104,10 +104,10 @@ impl Generator<validator::Info> for Validator {
     }
 
     fn generate(&self) -> Result<validator::Info, SimpleError> {
-        let keypair = self.get_private_key()?;
+        let verification_key = self.get_private_key()?.verification_key();
         let info = validator::Info {
-            address: account::Id::from(keypair.public),
-            pub_key: PublicKey::from(keypair.public),
+            address: account::Id::from(verification_key),
+            pub_key: PublicKey::from(verification_key),
             power: vote::Power::try_from(self.voting_power.unwrap_or(0)).unwrap(),
             name: None,
             proposer_priority: validator::ProposerPriority::from(

--- a/testgen/src/vote.rs
+++ b/testgen/src/vote.rs
@@ -5,7 +5,7 @@ use simple_error::*;
 use std::convert::TryFrom;
 use tendermint::{
     block::{self, parts::Header as PartSetHeader},
-    signature::{Ed25519Signature, Signature, Signer},
+    signature::{Ed25519Signature, Signature},
     vote,
     vote::ValidatorIndex,
 };
@@ -87,7 +87,7 @@ impl Generator<vote::Vote> for Vote {
             None => bail!("failed to generate vote: header is missing"),
             Some(h) => h,
         };
-        let signer = validator.get_private_key()?;
+        let signing_key = validator.get_private_key()?;
         let block_validator = validator.generate()?;
         let block_header = header.generate()?;
         let block_id = if self.nil.is_some() {
@@ -135,7 +135,7 @@ impl Generator<vote::Vote> for Vote {
         };
 
         let sign_bytes = get_vote_sign_bytes(block_header.chain_id, &vote);
-        vote.signature = Some(signer.sign(sign_bytes.as_slice()).into());
+        vote.signature = Some(signing_key.sign(sign_bytes.as_slice()).into());
 
         Ok(vote)
     }


### PR DESCRIPTION
Closes #355 (see that issue for more context; `ed25519-consensus` is a fork of
`ed25519-zebra` that's Zcash-independent).

This change ensures that `tendermint-rs` has the same signature verification as
`tendermint`, which uses the validation criteria provided by the Go
`ed25519consensus` library.

Submitted upstream as https://github.com/informalsystems/tendermint-rs/pull/1046 ; we can merge these changes into our fork in advance.